### PR TITLE
[002-FEAT] : Sign_Feat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 
 ### IntelliJ IDEA ###
 .idea
+*.properties
 *.iws
 *.iml
 *.ipr

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.data:spring-data-envers'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/scratch_user.http
+++ b/scratch_user.http
@@ -1,0 +1,22 @@
+### 회원가입
+POST http://localhost:8080/user/signup
+Content-Type: application/json
+
+{
+  "loginId": "중복확인",
+  "userNickName": "닉네임",
+  "userPassword": "159",
+  "userRank": "0"
+}
+
+
+### 로그인
+POST http://localhost:8080/user/signin
+Content-Type: application/json
+
+{
+  "loginId": "중복확인",
+  "userPassword": "159"
+}
+
+

--- a/src/main/java/com/example/board/BoardApplication.java
+++ b/src/main/java/com/example/board/BoardApplication.java
@@ -1,13 +1,20 @@
 package com.example.board;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@EnableJpaAuditing
+@EnableJpaRepositories
+@RequiredArgsConstructor
+@ServletComponentScan
 @SpringBootApplication
 public class BoardApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(BoardApplication.class, args);
     }
-
 }

--- a/src/main/java/com/example/board/config/EncoderConfig.java
+++ b/src/main/java/com/example/board/config/EncoderConfig.java
@@ -1,0 +1,31 @@
+package com.example.board.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class EncoderConfig extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.cors().disable()
+            .csrf().disable()
+            .formLogin().disable()
+            .headers().frameOptions().disable();
+    }
+}

--- a/src/main/java/com/example/board/config/TokenConfig.java
+++ b/src/main/java/com/example/board/config/TokenConfig.java
@@ -1,0 +1,14 @@
+package com.example.board.config;
+
+import com.example.board.security.TokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class TokenConfig {
+    @Bean
+    public TokenProvider tokenProvider() {
+        return new TokenProvider();
+    }
+}

--- a/src/main/java/com/example/board/controller/UserController.java
+++ b/src/main/java/com/example/board/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.example.board.controller;
+
+import com.example.board.domain.dto.UserDto;
+import com.example.board.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserController {
+
+    private final UserService userService;
+
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<String> userSignUp(@RequestBody UserDto.SignUp signUp) {
+        return ResponseEntity.ok(userService.userSignUp(signUp));
+    }
+
+
+    // 로그인
+    @PostMapping("/signin")
+    public ResponseEntity<String> memberSignIn(@RequestBody UserDto.SignIn signIn) {
+        return ResponseEntity.ok(userService.userSignIn(signIn));
+    }
+}

--- a/src/main/java/com/example/board/domain/dto/UserDto.java
+++ b/src/main/java/com/example/board/domain/dto/UserDto.java
@@ -1,0 +1,41 @@
+package com.example.board.domain.dto;
+
+import com.example.board.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+public class UserDto {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SignUp {
+
+        private String loginId;
+        private String userNickName;
+        private String userPassword;
+        private String userRank;
+
+        public User save(SignUp signUp) {
+            return User.builder()
+                .loginId(signUp.getLoginId())
+                .userNickName(signUp.getUserNickName())
+                .userPassword(signUp.getUserPassword())
+                .userRank(signUp.getUserRank())
+                .build();
+        }
+    }
+
+
+    @Getter
+    @Setter
+    public static class SignIn {
+        private String loginId;
+        private String userPassword;
+    }
+
+}

--- a/src/main/java/com/example/board/domain/entity/BaseEntity.java
+++ b/src/main/java/com/example/board/domain/entity/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.example.board.domain.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime updateDate;
+}

--- a/src/main/java/com/example/board/domain/entity/User.java
+++ b/src/main/java/com/example/board/domain/entity/User.java
@@ -1,0 +1,35 @@
+package com.example.board.domain.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(unique = true, columnDefinition = "VARCHAR(30) NOT NULL")
+    private String loginId;
+    @Column(columnDefinition = "VARCHAR(30) NOT NULL")
+    private String userNickName;
+    @Column(columnDefinition = "VARCHAR(255) NOT NULL")
+    private String userPassword;
+    @Column(columnDefinition = "VARCHAR(10) NOT NULL")
+    private String userRank;
+}

--- a/src/main/java/com/example/board/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/board/domain/repository/UserRepository.java
@@ -11,5 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByLoginId(String loginId);
 
+    boolean existsByUserNickName(String userNickName);
+
     Optional<User> findByLoginId(String loginId);
 }

--- a/src/main/java/com/example/board/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/board/domain/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.example.board.domain.repository;
+
+import com.example.board.domain.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByLoginId(String loginId);
+
+    Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/example/board/exception/ErrorCode.java
+++ b/src/main/java/com/example/board/exception/ErrorCode.java
@@ -9,6 +9,12 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
     ALREADY_LOGIN_ID("이미 사용중인 아이디 입니다."),
+    ALREADY_NICK_NAME("이미 사용중인 닉네임 입니다."),
+    BLANK_LOGIN_ID("아이디를 입력하세요."),
+    BLANK_NICK_NAME("닉네임을 입력하세요."),
+    BLANK_PASSWORD("비밀번호를 입력하세요."),
+
+
     NOT_FIND_LOGIN_ID("존재하지 않는 아이디 입니다."),
     WRONG_LOGIN_PASSWORD("비밀번호가 일치하지 않습니다.");
 

--- a/src/main/java/com/example/board/exception/ErrorCode.java
+++ b/src/main/java/com/example/board/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.board.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    ALREADY_LOGIN_ID("이미 사용중인 아이디 입니다."),
+    NOT_FIND_LOGIN_ID("존재하지 않는 아이디 입니다."),
+    WRONG_LOGIN_PASSWORD("비밀번호가 일치하지 않습니다.");
+
+
+    private final String MESSAGE;
+}

--- a/src/main/java/com/example/board/exception/ExceptionController.java
+++ b/src/main/java/com/example/board/exception/ExceptionController.java
@@ -1,0 +1,28 @@
+package com.example.board.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+
+@ControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ExceptionResponse> memberRequestException(
+        final GlobalException globalException) {
+        return ResponseEntity.badRequest().body(
+            new ExceptionResponse(globalException.getMessage(), globalException.getErrorCode()));
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    public static class ExceptionResponse {
+
+        private String message;
+        private ErrorCode errorCode;
+    }
+}

--- a/src/main/java/com/example/board/exception/GlobalException.java
+++ b/src/main/java/com/example/board/exception/GlobalException.java
@@ -1,0 +1,15 @@
+package com.example.board.exception;
+
+import lombok.Getter;
+
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public GlobalException(ErrorCode errorCode) {
+        super(errorCode.getMESSAGE());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/board/security/TokenProvider.java
+++ b/src/main/java/com/example/board/security/TokenProvider.java
@@ -1,0 +1,31 @@
+package com.example.board.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+
+
+public class TokenProvider {
+
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+
+    public String createToken(String loginId, String userRank) {
+        Claims claims = Jwts.claims().setSubject(loginId);
+        claims.put("roles", userRank);
+
+        Date now = new Date();
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + TOKEN_EXPIRE_TIME))
+            .signWith(SignatureAlgorithm.HS512, secretKey)
+            .compact();
+    }
+}

--- a/src/main/java/com/example/board/service/UserService.java
+++ b/src/main/java/com/example/board/service/UserService.java
@@ -1,51 +1,13 @@
 package com.example.board.service;
 
-import static com.example.board.exception.ErrorCode.ALREADY_LOGIN_ID;
-import static com.example.board.exception.ErrorCode.NOT_FIND_LOGIN_ID;
-import static com.example.board.exception.ErrorCode.WRONG_LOGIN_PASSWORD;
-
 import com.example.board.domain.dto.UserDto;
-import com.example.board.domain.entity.User;
-import com.example.board.domain.repository.UserRepository;
-import com.example.board.exception.GlobalException;
-import com.example.board.security.TokenProvider;
-import lombok.AllArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 
-@Service
-@AllArgsConstructor
-public class UserService {
-
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final TokenProvider tokenProvider;
-
+public interface UserService {
 
     // 회원가입
-    @Transactional
-    public String userSignUp(UserDto.SignUp signUp) {
-        if (userRepository.existsByLoginId(signUp.getLoginId())) {
-            throw new GlobalException(ALREADY_LOGIN_ID);
-        }
-        signUp.setUserPassword(passwordEncoder.encode(signUp.getUserPassword()));
-        userRepository.save(signUp.save(signUp));
-
-        return "회원가입이 완료 되었습니다.";
-    }
-
+    String userSignUp(UserDto.SignUp signUp);
 
     // 로그인
-    public String userSignIn(UserDto.SignIn signIn) {
-        User user = userRepository.findByLoginId(signIn.getLoginId())
-            .orElseThrow(() -> new GlobalException(NOT_FIND_LOGIN_ID));
-
-        if (!passwordEncoder.matches(signIn.getUserPassword(), user.getUserPassword())) {
-            throw new GlobalException(WRONG_LOGIN_PASSWORD);
-        }
-
-        return tokenProvider.createToken(user.getLoginId(), user.getUserRank());
-    }
+    String userSignIn(UserDto.SignIn signIn);
 }

--- a/src/main/java/com/example/board/service/UserService.java
+++ b/src/main/java/com/example/board/service/UserService.java
@@ -1,0 +1,51 @@
+package com.example.board.service;
+
+import static com.example.board.exception.ErrorCode.ALREADY_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.NOT_FIND_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.WRONG_LOGIN_PASSWORD;
+
+import com.example.board.domain.dto.UserDto;
+import com.example.board.domain.entity.User;
+import com.example.board.domain.repository.UserRepository;
+import com.example.board.exception.GlobalException;
+import com.example.board.security.TokenProvider;
+import lombok.AllArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@AllArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+
+
+    // 회원가입
+    @Transactional
+    public String userSignUp(UserDto.SignUp signUp) {
+        if (userRepository.existsByLoginId(signUp.getLoginId())) {
+            throw new GlobalException(ALREADY_LOGIN_ID);
+        }
+        signUp.setUserPassword(passwordEncoder.encode(signUp.getUserPassword()));
+        userRepository.save(signUp.save(signUp));
+
+        return "회원가입이 완료 되었습니다.";
+    }
+
+
+    // 로그인
+    public String userSignIn(UserDto.SignIn signIn) {
+        User user = userRepository.findByLoginId(signIn.getLoginId())
+            .orElseThrow(() -> new GlobalException(NOT_FIND_LOGIN_ID));
+
+        if (!passwordEncoder.matches(signIn.getUserPassword(), user.getUserPassword())) {
+            throw new GlobalException(WRONG_LOGIN_PASSWORD);
+        }
+
+        return tokenProvider.createToken(user.getLoginId(), user.getUserRank());
+    }
+}

--- a/src/main/java/com/example/board/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/board/service/impl/UserServiceImpl.java
@@ -1,0 +1,81 @@
+package com.example.board.service.impl;
+
+import static com.example.board.exception.ErrorCode.ALREADY_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.ALREADY_NICK_NAME;
+import static com.example.board.exception.ErrorCode.BLANK_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.BLANK_NICK_NAME;
+import static com.example.board.exception.ErrorCode.BLANK_PASSWORD;
+import static com.example.board.exception.ErrorCode.NOT_FIND_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.WRONG_LOGIN_PASSWORD;
+
+import com.example.board.domain.dto.UserDto;
+import com.example.board.domain.entity.User;
+import com.example.board.domain.repository.UserRepository;
+import com.example.board.exception.GlobalException;
+import com.example.board.security.TokenProvider;
+import com.example.board.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+
+
+    // 회원가입
+    @Transactional
+    public String userSignUp(UserDto.SignUp signUp) {
+        // 아이디 확인
+        if (signUp.getLoginId().equals("")) {
+            throw new GlobalException(BLANK_LOGIN_ID);
+        } else if (userRepository.existsByLoginId(signUp.getLoginId())) {
+            throw new GlobalException(ALREADY_LOGIN_ID);
+        }
+
+        // 닉네임 확인
+        if (signUp.getUserNickName().equals("")) {
+            throw new GlobalException(BLANK_NICK_NAME);
+        } else if (userRepository.existsByUserNickName(signUp.getUserNickName())) {
+            throw new GlobalException(ALREADY_NICK_NAME);
+        }
+
+        // 비밀번호 확인
+        if (signUp.getUserPassword().equals("")) {
+            throw new GlobalException(BLANK_PASSWORD);
+        }
+
+        signUp.setUserPassword(passwordEncoder.encode(signUp.getUserPassword()));
+        userRepository.save(signUp.save(signUp));
+
+        return "회원가입이 완료 되었습니다.";
+    }
+
+
+    // 로그인
+    public String userSignIn(UserDto.SignIn signIn) {
+
+        // 입력값 확인
+        if (signIn.getLoginId().equals("")) {
+            throw new GlobalException(BLANK_LOGIN_ID);
+        }
+        if (signIn.getUserPassword().equals("")) {
+            throw new GlobalException(BLANK_PASSWORD);
+        }
+
+        User user = userRepository.findByLoginId(signIn.getLoginId())
+            .orElseThrow(() -> new GlobalException(NOT_FIND_LOGIN_ID));
+
+        if (!passwordEncoder.matches(signIn.getUserPassword(), user.getUserPassword())) {
+            throw new GlobalException(WRONG_LOGIN_PASSWORD);
+        }
+
+        return tokenProvider.createToken(user.getLoginId(), user.getUserRank());
+    }
+}


### PR DESCRIPTION
### FEAT : SignUp(회원가입), SignIn(로그인) 기능 추가 

**AS-IS**
1. 회원가입
    (1) 회원가입을 진행할 수 있다.
    (2) 아이디, 닉네임, 비밀번호를 입력 받는다.
    (3) 등급은 0부터 5까지 있으며, 0은 관리자 1부터 5까지는 회원으로 회원가입 시 1로 자동 등록된다.
2. 로그인
    (1) 아이디, 비밀번호가 일치해야 한다.

**TO-BE**
1. 회원가입
    - [x] 회원가입을 진행할 수 있다.
    - [x] 아이디, 닉네임, 비밀번호를 입력 받는다.
    - [ ] 등급은 0부터 5까지 있으며, 0은 관리자 1부터 5까지는 회원으로 회원가입 시 1로 자동 등록된다.
       (1) 현재 입력 받아 저장하는 방법으로 구현 
3. 로그인
    - [x] 아이디, 비밀번호가 일치해야 한다.

### FeedBack

**AS-IS**
1. 회원가입
    (1) 닉네임 중복 체크
    (2) 공백일 경우
2. 로그인
    (1) 공백일 경우

**TO-BE**
1. 회원가입
    - [x] 닉네임 중복 체크
    - [x] 공백일 경우
2. 로그인
    - [x] 공백일 경우


### 테스트
1. scratch_user.http 를 생성하여 테스트 진행 하였음