### PR TITLE
[008-FEAT] : RankUpStandard

### DIFF
--- a/scratch_rankupstandard.http
+++ b/scratch_rankupstandard.http
@@ -1,18 +1,17 @@
 ### 등업 기준 조회
 GET http://localhost:8080/rankup/search
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg0OTg0OTMwLCJleHAiOjE2ODUwNzEzMzB9.Ofe3rv-8sPzEkkJf4S5BOuqpr7eqhcTHvU2RPKkkXKKwrN1oTRpWx7_TSZPgCWmr28UrY_ELPYk7LqZpVg4Eew
 
 
 ### 등업 기준 저장
 POST http://localhost:8080/rankup/add
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg0OTg0OTMwLCJleHAiOjE2ODUwNzEzMzB9.Ofe3rv-8sPzEkkJf4S5BOuqpr7eqhcTHvU2RPKkkXKKwrN1oTRpWx7_TSZPgCWmr28UrY_ELPYk7LqZpVg4Eew
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg1MDgyMjU2LCJleHAiOjE2ODUxNjg2NTZ9.ZybLOZa-r3HWfaqvxnbX1rTXoW94NROXqDlPAu5JwflYZyyH-t32sOfP2loKXynyv9qFweTtvpmTldDKkDwZ2w
 
 {
   "rankName": "LEVEL3",
-  "boardCount": 3,
-  "commentCount": 3,
+  "boardCount": 10,
+  "commentCount": 10,
   "autoRankUpFlag": true
 }
 
@@ -20,7 +19,7 @@ USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxR
 ### 등업 기준 수정
 PUT http://localhost:8080/rankup/modify/2
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiI4Y21vdWphU2EzNmpkeHltdWZHRC9YRHFCVW5PNlI3U1EyY0VUSEpsczdBPSIsInJvbGVzIjoiQURNSU4iLCJpYXQiOjE2ODQ5MjU0MDgsImV4cCI6MTY4NTAxMTgwOH0.1Taliqx3wnWIWJ4BlO3PYLWx1dv2qWyihXCNsYTDhw02H9ka5-X2sAWKjDMGTRhNg6JuZGmVEvxXUVg3POqsbQ
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg1MDgyMDM1LCJleHAiOjE2ODUxNjg0MzV9.X1Y2m6D8MTgtW0A3hxXpJeB-G0e70JAehEldesN1JryhwsGr97r3-Yl6jlVPqE-1GRV1srkm6dWcrHwjTOl9bQ
 
 {
   "boardCount": 10,
@@ -30,7 +29,6 @@ USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxR
 
 
 ### 등업 기준 삭제
-DELETE http://localhost:8080/rankup/delete/3
+DELETE http://localhost:8080/rankup/delete/1
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiI4Y21vdWphU2EzNmpkeHltdWZHRC9YRHFCVW5PNlI3U1EyY0VUSEpsczdBPSIsInJvbGVzIjoiQURNSU4iLCJpYXQiOjE2ODQ5MjU0MDgsImV4cCI6MTY4NTAxMTgwOH0.1Taliqx3wnWIWJ4BlO3PYLWx1dv2qWyihXCNsYTDhw02H9ka5-X2sAWKjDMGTRhNg6JuZGmVEvxXUVg3POqsbQ
-
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg1MDgyMjU2LCJleHAiOjE2ODUxNjg2NTZ9.ZybLOZa-r3HWfaqvxnbX1rTXoW94NROXqDlPAu5JwflYZyyH-t32sOfP2loKXynyv9qFweTtvpmTldDKkDwZ2w

--- a/scratch_rankupstandard.http
+++ b/scratch_rankupstandard.http
@@ -1,0 +1,36 @@
+### 등업 기준 조회
+GET http://localhost:8080/rankup/search
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg0OTg0OTMwLCJleHAiOjE2ODUwNzEzMzB9.Ofe3rv-8sPzEkkJf4S5BOuqpr7eqhcTHvU2RPKkkXKKwrN1oTRpWx7_TSZPgCWmr28UrY_ELPYk7LqZpVg4Eew
+
+
+### 등업 기준 저장
+POST http://localhost:8080/rankup/add
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg0OTg0OTMwLCJleHAiOjE2ODUwNzEzMzB9.Ofe3rv-8sPzEkkJf4S5BOuqpr7eqhcTHvU2RPKkkXKKwrN1oTRpWx7_TSZPgCWmr28UrY_ELPYk7LqZpVg4Eew
+
+{
+  "rankName": "LEVEL3",
+  "boardCount": 3,
+  "commentCount": 3,
+  "autoRankUpFlag": true
+}
+
+
+### 등업 기준 수정
+PUT http://localhost:8080/rankup/modify/2
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiI4Y21vdWphU2EzNmpkeHltdWZHRC9YRHFCVW5PNlI3U1EyY0VUSEpsczdBPSIsInJvbGVzIjoiQURNSU4iLCJpYXQiOjE2ODQ5MjU0MDgsImV4cCI6MTY4NTAxMTgwOH0.1Taliqx3wnWIWJ4BlO3PYLWx1dv2qWyihXCNsYTDhw02H9ka5-X2sAWKjDMGTRhNg6JuZGmVEvxXUVg3POqsbQ
+
+{
+  "boardCount": 10,
+  "commentCount": 10,
+  "autoRankUpFlag": true
+}
+
+
+### 등업 기준 삭제
+DELETE http://localhost:8080/rankup/delete/3
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiI4Y21vdWphU2EzNmpkeHltdWZHRC9YRHFCVW5PNlI3U1EyY0VUSEpsczdBPSIsInJvbGVzIjoiQURNSU4iLCJpYXQiOjE2ODQ5MjU0MDgsImV4cCI6MTY4NTAxMTgwOH0.1Taliqx3wnWIWJ4BlO3PYLWx1dv2qWyihXCNsYTDhw02H9ka5-X2sAWKjDMGTRhNg6JuZGmVEvxXUVg3POqsbQ
+

--- a/scratch_sign.http
+++ b/scratch_sign.http
@@ -3,11 +3,10 @@ POST http://localhost:8080/signup/admin
 Content-Type: application/json
 
 {
-  "loginId": "관리자",
-  "userNickName": "첫번째 관리자",
-  "userPassword": "1234"
+  "loginId": "administrator",
+  "userNickName": "관리자",
+  "userPassword": "abcdefgh1!"
 }
-
 
 
 ### 회원 회원가입
@@ -15,9 +14,9 @@ POST http://localhost:8080/signup/user
 Content-Type: application/json
 
 {
-  "loginId": "회원",
-  "userNickName": "회원1",
-  "userPassword": "1111"
+  "loginId": "ohdonggeon",
+  "userNickName": "먼지제거제",
+  "userPassword": "zxcvbnm123@"
 }
 
 
@@ -26,8 +25,6 @@ POST http://localhost:8080/signin
 Content-Type: application/json
 
 {
-  "loginId": "관리자",
-  "userPassword": "1234"
+  "loginId": "administrator",
+  "userPassword": "abcdefgh1!"
 }
-
-

--- a/src/main/java/com/example/board/controller/RankUpStandardController.java
+++ b/src/main/java/com/example/board/controller/RankUpStandardController.java
@@ -1,0 +1,75 @@
+package com.example.board.controller;
+
+import com.example.board.domain.dto.RankUpStandardDto.AddRankUpStandard;
+import com.example.board.domain.dto.RankUpStandardDto.ModifyRankUpStandard;
+import com.example.board.domain.dto.RankUpStandardDto.SearchRankUpStandard;
+import com.example.board.security.TokenProvider;
+import com.example.board.service.RankUpStandardService;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rankup")
+public class RankUpStandardController {
+
+    private final RankUpStandardService rankUpStandardService;
+    private final TokenProvider tokenProvider;
+    public final String TOKEN_HEADER = "USER_TOKEN_HEADER";
+
+
+    // 조회
+    @GetMapping("/search")
+    public ResponseEntity<List<SearchRankUpStandard>> searchRankUpStandard(
+        @RequestHeader(name = TOKEN_HEADER) String token) {
+
+        return ResponseEntity.ok(rankUpStandardService.searchRankUpStandard(
+            tokenProvider.getTokenUserId(token), true));
+    }
+
+
+    // 저장
+    @PostMapping("/add")
+    public ResponseEntity<List<SearchRankUpStandard>> addRankUpStandard(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @RequestBody @Valid AddRankUpStandard addRankUpStandard) {
+
+        return ResponseEntity.ok(rankUpStandardService.addRankUpStandard(
+            tokenProvider.getTokenUserId(token), addRankUpStandard));
+    }
+
+
+    // 수정
+    @PutMapping("/modify/{standardId}")
+    public ResponseEntity<List<SearchRankUpStandard>> modifyRankUpStandard(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @PathVariable("standardId") Long standardId,
+        @RequestBody @Valid ModifyRankUpStandard modifyRankUpStandard) {
+
+        return ResponseEntity.ok(rankUpStandardService.modifyRankUpStandard(
+            tokenProvider.getTokenUserId(token), standardId, modifyRankUpStandard));
+    }
+
+
+    // 삭제
+    @DeleteMapping("/delete/{standardId}")
+    public ResponseEntity<List<SearchRankUpStandard>> deleteRankUpStandard(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @PathVariable("standardId") Long standardId) {
+
+        return ResponseEntity.ok(rankUpStandardService.deleteRankUpStandard(
+            tokenProvider.getTokenUserId(token), standardId));
+    }
+}

--- a/src/main/java/com/example/board/controller/RankUpStandardController.java
+++ b/src/main/java/com/example/board/controller/RankUpStandardController.java
@@ -1,8 +1,8 @@
 package com.example.board.controller;
 
-import com.example.board.domain.dto.RankUpStandardDto.AddRankUpStandard;
-import com.example.board.domain.dto.RankUpStandardDto.ModifyRankUpStandard;
 import com.example.board.domain.dto.RankUpStandardDto.SearchRankUpStandard;
+import com.example.board.domain.form.RankUpStandardForm.AddRankUpStandard;
+import com.example.board.domain.form.RankUpStandardForm.ModifyRankUpStandard;
 import com.example.board.security.TokenProvider;
 import com.example.board.service.RankUpStandardService;
 import java.util.List;
@@ -32,11 +32,9 @@ public class RankUpStandardController {
 
     // 조회
     @GetMapping("/search")
-    public ResponseEntity<List<SearchRankUpStandard>> searchRankUpStandard(
-        @RequestHeader(name = TOKEN_HEADER) String token) {
+    public ResponseEntity<List<SearchRankUpStandard>> searchRankUpStandard() {
 
-        return ResponseEntity.ok(rankUpStandardService.searchRankUpStandard(
-            tokenProvider.getTokenUserId(token), true));
+        return ResponseEntity.ok(rankUpStandardService.searchRankUpStandard());
     }
 
 

--- a/src/main/java/com/example/board/controller/SignInController.java
+++ b/src/main/java/com/example/board/controller/SignInController.java
@@ -1,6 +1,6 @@
 package com.example.board.controller;
 
-import com.example.board.domain.dto.UserDto;
+import com.example.board.domain.form.UserForm.SignIn;
 import com.example.board.service.SignInService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,8 @@ public class SignInController {
 
     // 로그인
     @PostMapping("/signin")
-    public ResponseEntity<String> memberSignIn(@RequestBody @Valid UserDto.SignIn signIn) {
+    public ResponseEntity<String> memberSignIn(@RequestBody @Valid SignIn signIn) {
+
         return ResponseEntity.ok(signInService.signIn(signIn));
     }
 }

--- a/src/main/java/com/example/board/controller/SignUpController.java
+++ b/src/main/java/com/example/board/controller/SignUpController.java
@@ -3,7 +3,7 @@ package com.example.board.controller;
 import static com.example.board.domain.type.UserType.ADMIN;
 import static com.example.board.domain.type.UserType.USER;
 
-import com.example.board.domain.dto.UserDto;
+import com.example.board.domain.form.UserForm.SignUp;
 import com.example.board.service.SignUpService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +22,16 @@ public class SignUpController {
 
     // 관리자 회원가입
     @PostMapping("/signup/admin")
-    public ResponseEntity<String> adminSignUp(@RequestBody @Valid UserDto.SignUp signUp) {
+    public ResponseEntity<String> adminSignUp(@RequestBody @Valid SignUp signUp) {
+
         return ResponseEntity.ok(signUpService.signUp(signUp, ADMIN));
     }
 
 
     // 회원 회원가입
     @PostMapping("/signup/user")
-    public ResponseEntity<String> userSignUp(@RequestBody @Valid UserDto.SignUp signUp) {
+    public ResponseEntity<String> userSignUp(@RequestBody @Valid SignUp signUp) {
+
         return ResponseEntity.ok(signUpService.signUp(signUp, USER));
     }
 }

--- a/src/main/java/com/example/board/domain/dto/RankUpStandardDto.java
+++ b/src/main/java/com/example/board/domain/dto/RankUpStandardDto.java
@@ -1,11 +1,6 @@
 package com.example.board.domain.dto;
 
-import com.example.board.domain.entity.RankUpStandard;
 import com.example.board.domain.type.RankType;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,54 +21,6 @@ public class RankUpStandardDto {
         private RankType rankName;
         private Long boardCount;
         private Long commentCount;
-        private boolean autoRankUpFlag;
-    }
-
-
-    @Getter
-    @Setter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AddRankUpStandard {
-
-        @NotNull(message = "등급을 확인해주세요.")
-        @Enumerated(EnumType.STRING)
-        private RankType rankName;
-        @NotNull(message = "게시글 작성 수를 입력하세요.")
-        @Min(value = 0, message = "게시글 작성 수는 0이상 입니다.")
-        private Long boardCount;
-        @NotNull(message = "댓글 작성 수를 입력하세요.")
-        @Min(value = 0, message = "댓글 작성 수는 0이상 입니다.")
-        private Long commentCount;
-        @NotNull(message = "자동 등업 여부를 선택하세요.")
-        private boolean autoRankUpFlag;
-
-        public RankUpStandard save(AddRankUpStandard addRankUpStandard) {
-            return RankUpStandard.builder()
-                .rankName(addRankUpStandard.getRankName())
-                .boardCount(addRankUpStandard.getBoardCount())
-                .commentCount(addRankUpStandard.getCommentCount())
-                .autoRankUpFlag(addRankUpStandard.isAutoRankUpFlag())
-                .build();
-        }
-    }
-
-
-    @Getter
-    @Setter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class ModifyRankUpStandard {
-
-        @NotNull(message = "게시글 작성 수를 입력하세요.")
-        @Min(value = 0, message = "게시글 작성 수는 0이상 입니다.")
-        private Long boardCount;
-        @NotNull(message = "댓글 작성 수를 입력하세요.")
-        @Min(value = 0, message = "댓글 작성 수는 0이상 입니다.")
-        private Long commentCount;
-        @NotNull(message = "자동 등업 여부를 선택하세요.")
         private boolean autoRankUpFlag;
     }
 }

--- a/src/main/java/com/example/board/domain/dto/RankUpStandardDto.java
+++ b/src/main/java/com/example/board/domain/dto/RankUpStandardDto.java
@@ -1,0 +1,79 @@
+package com.example.board.domain.dto;
+
+import com.example.board.domain.entity.RankUpStandard;
+import com.example.board.domain.type.RankType;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+public class RankUpStandardDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchRankUpStandard {
+
+        private Long standardId;
+        private RankType rankName;
+        private Long boardCount;
+        private Long commentCount;
+        private boolean autoRankUpFlag;
+    }
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddRankUpStandard {
+
+        @NotNull(message = "등급을 확인해주세요.")
+        @Enumerated(EnumType.STRING)
+        private RankType rankName;
+        @NotNull(message = "게시글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "게시글 작성 수는 0이상 입니다.")
+        private Long boardCount;
+        @NotNull(message = "댓글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "댓글 작성 수는 0이상 입니다.")
+        private Long commentCount;
+        @NotNull(message = "자동 등업 여부를 선택하세요.")
+        private boolean autoRankUpFlag;
+
+        public RankUpStandard save(AddRankUpStandard addRankUpStandard) {
+            return RankUpStandard.builder()
+                .rankName(addRankUpStandard.getRankName())
+                .boardCount(addRankUpStandard.getBoardCount())
+                .commentCount(addRankUpStandard.getCommentCount())
+                .autoRankUpFlag(addRankUpStandard.isAutoRankUpFlag())
+                .build();
+        }
+    }
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ModifyRankUpStandard {
+
+        @NotNull(message = "게시글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "게시글 작성 수는 0이상 입니다.")
+        private Long boardCount;
+        @NotNull(message = "댓글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "댓글 작성 수는 0이상 입니다.")
+        private Long commentCount;
+        @NotNull(message = "자동 등업 여부를 선택하세요.")
+        private boolean autoRankUpFlag;
+    }
+}

--- a/src/main/java/com/example/board/domain/entity/RankUpStandard.java
+++ b/src/main/java/com/example/board/domain/entity/RankUpStandard.java
@@ -1,9 +1,6 @@
 package com.example.board.domain.entity;
 
 import com.example.board.domain.type.RankType;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -12,39 +9,36 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
+import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.envers.AuditOverride;
 
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
-public class User extends BaseEntity {
+public class RankUpStandard extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userId;
-
-    @Column(unique = true, columnDefinition = "VARCHAR(30) NOT NULL")
-    private String loginId;
-    @Column(columnDefinition = "VARCHAR(30) NOT NULL")
-    private String userNickName;
-    @Column(columnDefinition = "VARCHAR(255) NOT NULL")
-    private String userPassword;
+    private Long standardId;
 
     @Column(columnDefinition = "VARCHAR(10) NOT NULL")
     @Enumerated(EnumType.STRING)
-    private RankType userRank;
+    private RankType rankName;
+    private Long boardCount;
+    private Long commentCount;
+    private boolean autoRankUpFlag;
 
-
-    @OneToMany(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "createdUserId")
-    private List<RankUpStandard> rankUpStandards = new ArrayList<>();
+    private User user;
 }

--- a/src/main/java/com/example/board/domain/form/RankUpStandardForm.java
+++ b/src/main/java/com/example/board/domain/form/RankUpStandardForm.java
@@ -1,0 +1,54 @@
+package com.example.board.domain.form;
+
+import com.example.board.domain.type.RankType;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+public class RankUpStandardForm {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddRankUpStandard {
+
+        @NotNull(message = "등급을 확인해주세요.")
+        @Enumerated(EnumType.STRING)
+        private RankType rankName;
+        @NotNull(message = "게시글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "게시글 작성 수는 0이상 입니다.")
+        private Long boardCount;
+        @NotNull(message = "댓글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "댓글 작성 수는 0이상 입니다.")
+        private Long commentCount;
+        @NotNull(message = "자동 등업 여부를 선택하세요.")
+        private boolean autoRankUpFlag;
+    }
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ModifyRankUpStandard {
+
+        @NotNull(message = "게시글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "게시글 작성 수는 0이상 입니다.")
+        private Long boardCount;
+        @NotNull(message = "댓글 작성 수를 입력하세요.")
+        @Min(value = 0, message = "댓글 작성 수는 0이상 입니다.")
+        private Long commentCount;
+        @NotNull(message = "자동 등업 여부를 선택하세요.")
+        private boolean autoRankUpFlag;
+    }
+}

--- a/src/main/java/com/example/board/domain/form/UserForm.java
+++ b/src/main/java/com/example/board/domain/form/UserForm.java
@@ -1,8 +1,5 @@
-package com.example.board.domain.dto;
+package com.example.board.domain.form;
 
-import com.example.board.domain.entity.User;
-import com.example.board.domain.type.RankType;
-import com.example.board.domain.type.UserType;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -11,8 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-
-public class UserDto {
+public class UserForm {
 
     @Getter
     @Setter
@@ -28,17 +24,8 @@ public class UserDto {
         private String userNickName;
         @NotBlank(message = "비밀번호를 입력하세요.")
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{10,}",
-                 message = "비밀번호는 10자 이상, 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+            message = "비밀번호는 10자 이상, 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
         private String userPassword;
-
-        public User save(SignUp signUp, UserType userType) {
-            return User.builder()
-                .loginId(signUp.getLoginId())
-                .userNickName(signUp.getUserNickName())
-                .userPassword(signUp.getUserPassword())
-                .userRank(userType.equals(UserType.USER) ? RankType.LEVEL1 : RankType.ADMIN)
-                .build();
-        }
     }
 
 

--- a/src/main/java/com/example/board/domain/repository/RankUpStandardRepository.java
+++ b/src/main/java/com/example/board/domain/repository/RankUpStandardRepository.java
@@ -1,0 +1,22 @@
+package com.example.board.domain.repository;
+
+import com.example.board.domain.entity.RankUpStandard;
+import com.example.board.domain.type.RankType;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RankUpStandardRepository extends JpaRepository<RankUpStandard, Long> {
+
+    List<RankUpStandard> findAllByOrderByRankName();
+
+    Optional<RankUpStandard> findByStandardId(Long standardId);
+
+    Optional<RankUpStandard> findTop1ByRankNameLessThanOrderByRankNameDesc(RankType rankName);
+
+    Optional<RankUpStandard> findTop1ByRankNameGreaterThanOrderByRankName(RankType rankName);
+
+    boolean existsByRankName(RankType rankName);
+}

--- a/src/main/java/com/example/board/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/board/domain/repository/UserRepository.java
@@ -13,5 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUserNickName(String userNickName);
 
+    Optional<User> findByUserId(Long userId);
+
     Optional<User> findByLoginId(String loginId);
 }

--- a/src/main/java/com/example/board/domain/type/RankType.java
+++ b/src/main/java/com/example/board/domain/type/RankType.java
@@ -1,6 +1,10 @@
 package com.example.board.domain.type;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.stream.Stream;
+
 public enum RankType {
+
     // 관리자
     ADMIN,
 
@@ -9,5 +13,13 @@ public enum RankType {
     LEVEL2,
     LEVEL3,
     LEVEL4,
-    LEVEL5
+    LEVEL5;
+
+    @JsonCreator
+    public static RankType parsing(String inputValue) {
+        return Stream.of(RankType.values())
+            .filter(category -> category.toString().equals(inputValue.toUpperCase()))
+            .findFirst()
+            .orElse(null);
+    }
 }

--- a/src/main/java/com/example/board/exception/ErrorCode.java
+++ b/src/main/java/com/example/board/exception/ErrorCode.java
@@ -7,16 +7,21 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-
+    // 회원 관련
     ALREADY_LOGIN_ID("이미 사용중인 아이디 입니다."),
     ALREADY_NICK_NAME("이미 사용중인 닉네임 입니다."),
-    BLANK_LOGIN_ID("아이디를 입력하세요."),
-    BLANK_NICK_NAME("닉네임을 입력하세요."),
-    BLANK_PASSWORD("비밀번호를 입력하세요."),
 
-
+    // 로그인
     NOT_FIND_LOGIN_ID("존재하지 않는 아이디 입니다."),
-    WRONG_LOGIN_PASSWORD("비밀번호가 일치하지 않습니다.");
+    WRONG_LOGIN_PASSWORD("비밀번호가 일치하지 않습니다."),
+
+    // 등급 관련
+    ALREADY_RANK("이미 등록된 등급 입니다."),
+    NOT_ADD_RANK("등록할 수 없는 등급 입니다."),
+    NOT_FIND_RANK("존재하지 않는 등급 입니다."),
+    NOT_MATCH_USER_RANK("회원 등급이 맞지 않습니다."),
+    UNDER_RANK_CHECK_BOARD_COMMENT("이전 등급의 게시글 수, 댓글 수 보다 크게 입력하세요."),
+    OVER_RANK_CHECK_BOARD_COMMENT("다음 등급의 게시글 수, 댓글 수 보다 적게 입력하세요.");
 
 
     private final String MESSAGE;

--- a/src/main/java/com/example/board/exception/ExceptionController.java
+++ b/src/main/java/com/example/board/exception/ExceptionController.java
@@ -17,6 +17,7 @@ public class ExceptionController {
     @ExceptionHandler(GlobalException.class)
     public ResponseEntity<ExceptionResponse> globalRequestException(
         final GlobalException globalException) {
+
         return ResponseEntity.badRequest().body(
             new ExceptionResponse(globalException.getMessage(), globalException.getErrorCode()));
     }
@@ -28,7 +29,7 @@ public class ExceptionController {
         final MethodArgumentNotValidException methodArgumentNotValidException) {
 
         ObjectError objectError = methodArgumentNotValidException.getBindingResult()
-                                        .getAllErrors().get(0);
+            .getAllErrors().get(0);
 
         return ResponseEntity.badRequest().body(
             new ExceptionResponse(objectError.getDefaultMessage(),

--- a/src/main/java/com/example/board/security/TokenProvider.java
+++ b/src/main/java/com/example/board/security/TokenProvider.java
@@ -1,23 +1,26 @@
 package com.example.board.security;
 
 import com.example.board.domain.type.RankType;
+import com.example.board.security.util.Aes256util;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 
 
 public class TokenProvider {
 
-    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;
-
     @Value("${spring.jwt.secret}")
     private String secretKey;
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;
 
 
-    public String createToken(String loginId, RankType userRank) {
-        Claims claims = Jwts.claims().setSubject(loginId);
+    public String createToken(Long userId, String loginId, RankType userRank) {
+        Claims claims = Jwts.claims().setId(Aes256util.encrypt(userId.toString()))
+            .setSubject(Aes256util.encrypt(loginId));
+
         claims.put("roles", userRank);
 
         Date now = new Date();
@@ -28,5 +31,22 @@ public class TokenProvider {
             .setExpiration(new Date(now.getTime() + TOKEN_EXPIRE_TIME))
             .signWith(SignatureAlgorithm.HS512, secretKey)
             .compact();
+    }
+
+
+    public Long getTokenUserId(String token) {
+        Claims claims = parseClaims(token);
+        return Long.valueOf(Objects.requireNonNull(Aes256util.decrypt(claims.getId())));
+    }
+
+
+    public boolean validateToken(String token) {
+        Claims claims = parseClaims(token);
+        return !claims.getExpiration().before(new Date());
+    }
+
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
     }
 }

--- a/src/main/java/com/example/board/security/filter/TokenFilter.java
+++ b/src/main/java/com/example/board/security/filter/TokenFilter.java
@@ -14,7 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 
 @RequiredArgsConstructor
-@WebFilter(urlPatterns = "/rankup/*")
+@WebFilter(urlPatterns = {"/rankup/add/*", "/rankup/modify/*", "/rankup/delete/*"})
 public class TokenFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;

--- a/src/main/java/com/example/board/security/filter/TokenFilter.java
+++ b/src/main/java/com/example/board/security/filter/TokenFilter.java
@@ -1,0 +1,40 @@
+package com.example.board.security.filter;
+
+import com.example.board.domain.repository.UserRepository;
+import com.example.board.security.TokenProvider;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+@RequiredArgsConstructor
+@WebFilter(urlPatterns = "/rankup/*")
+public class TokenFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    public final String TOKEN_HEADER = "USER_TOKEN_HEADER";
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!StringUtils.hasText(token) || !tokenProvider.validateToken(token)) {
+            throw new ServletException("유효하지 않은 접근입니다.");
+        }
+
+        userRepository.findByUserId(tokenProvider.getTokenUserId(token))
+            .orElseThrow(() -> new ServletException("유효하지 않은 접근입니다."));
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/board/security/util/Aes256util.java
+++ b/src/main/java/com/example/board/security/util/Aes256util.java
@@ -1,0 +1,53 @@
+package com.example.board.security.util;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.tomcat.util.codec.binary.Base64;
+
+
+public class Aes256util {
+
+    public static String alg = "AES/CBC/PKCS5Padding";
+    private static final String KEY = "PROJECT_BOARD_OHDONGGEON";
+
+    private static final String IV = KEY.substring(0, 16);
+
+
+    // 암호화
+    public static String encrypt(String text) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(
+                IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+
+            return Base64.encodeBase64String(encrypted);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+
+    // 복호화
+    public static String decrypt(String cipherText) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(
+                IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] decryptBytes = Base64.decodeBase64(cipherText);
+            byte[] decrypted = cipher.doFinal(decryptBytes);
+
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/example/board/service/RankUpStandardService.java
+++ b/src/main/java/com/example/board/service/RankUpStandardService.java
@@ -1,0 +1,28 @@
+package com.example.board.service;
+
+import com.example.board.domain.dto.RankUpStandardDto.AddRankUpStandard;
+import com.example.board.domain.dto.RankUpStandardDto.ModifyRankUpStandard;
+import com.example.board.domain.dto.RankUpStandardDto.SearchRankUpStandard;
+import java.util.List;
+
+
+public interface RankUpStandardService {
+
+    // 조회
+    List<SearchRankUpStandard> searchRankUpStandard(Long userId, boolean userTypeCheck);
+
+
+    // 저장
+    List<SearchRankUpStandard> addRankUpStandard(
+        Long userId, AddRankUpStandard addRankUpStandard);
+
+
+    // 수정
+    List<SearchRankUpStandard> modifyRankUpStandard(
+        Long userId, Long standardId, ModifyRankUpStandard modifyRankUpStandard);
+
+
+    // 삭제
+    List<SearchRankUpStandard> deleteRankUpStandard(Long userId, Long standardId);
+
+}

--- a/src/main/java/com/example/board/service/RankUpStandardService.java
+++ b/src/main/java/com/example/board/service/RankUpStandardService.java
@@ -1,15 +1,15 @@
 package com.example.board.service;
 
-import com.example.board.domain.dto.RankUpStandardDto.AddRankUpStandard;
-import com.example.board.domain.dto.RankUpStandardDto.ModifyRankUpStandard;
 import com.example.board.domain.dto.RankUpStandardDto.SearchRankUpStandard;
+import com.example.board.domain.form.RankUpStandardForm.AddRankUpStandard;
+import com.example.board.domain.form.RankUpStandardForm.ModifyRankUpStandard;
 import java.util.List;
 
 
 public interface RankUpStandardService {
 
     // 조회
-    List<SearchRankUpStandard> searchRankUpStandard(Long userId, boolean userTypeCheck);
+    List<SearchRankUpStandard> searchRankUpStandard();
 
 
     // 저장

--- a/src/main/java/com/example/board/service/SignInService.java
+++ b/src/main/java/com/example/board/service/SignInService.java
@@ -1,9 +1,9 @@
 package com.example.board.service;
 
-import com.example.board.domain.dto.UserDto;
+import com.example.board.domain.form.UserForm.SignIn;
 
 public interface SignInService {
 
     // 로그인
-    String signIn(UserDto.SignIn signIn);
+    String signIn(SignIn signIn);
 }

--- a/src/main/java/com/example/board/service/SignUpService.java
+++ b/src/main/java/com/example/board/service/SignUpService.java
@@ -1,11 +1,11 @@
 package com.example.board.service;
 
-import com.example.board.domain.dto.UserDto;
+import com.example.board.domain.form.UserForm.SignUp;
 import com.example.board.domain.type.UserType;
 
 
 public interface SignUpService {
 
     // 회원가입
-    String signUp(UserDto.SignUp signUp, UserType signLocation);
+    String signUp(SignUp signUp, UserType signLocation);
 }

--- a/src/main/java/com/example/board/service/UserTypeCheckService.java
+++ b/src/main/java/com/example/board/service/UserTypeCheckService.java
@@ -1,0 +1,9 @@
+package com.example.board.service;
+
+import com.example.board.domain.entity.User;
+
+
+public interface UserTypeCheckService {
+
+    User userTypeAdmin(Long userId);
+}

--- a/src/main/java/com/example/board/service/impl/RankUpStandardImpl.java
+++ b/src/main/java/com/example/board/service/impl/RankUpStandardImpl.java
@@ -1,0 +1,147 @@
+package com.example.board.service.impl;
+
+import static com.example.board.domain.type.RankType.ADMIN;
+import static com.example.board.exception.ErrorCode.ALREADY_RANK;
+import static com.example.board.exception.ErrorCode.NOT_ADD_RANK;
+import static com.example.board.exception.ErrorCode.NOT_FIND_RANK;
+import static com.example.board.exception.ErrorCode.OVER_RANK_CHECK_BOARD_COMMENT;
+import static com.example.board.exception.ErrorCode.UNDER_RANK_CHECK_BOARD_COMMENT;
+
+import com.example.board.domain.dto.RankUpStandardDto.AddRankUpStandard;
+import com.example.board.domain.dto.RankUpStandardDto.ModifyRankUpStandard;
+import com.example.board.domain.dto.RankUpStandardDto.SearchRankUpStandard;
+import com.example.board.domain.entity.RankUpStandard;
+import com.example.board.domain.entity.User;
+import com.example.board.domain.repository.RankUpStandardRepository;
+import com.example.board.domain.type.RankType;
+import com.example.board.exception.GlobalException;
+import com.example.board.service.RankUpStandardService;
+import com.example.board.service.UserTypeCheckService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class RankUpStandardImpl implements RankUpStandardService {
+
+    private final UserTypeCheckService userTypeCheckService;
+    private final RankUpStandardRepository rankUpStandardRepository;
+
+
+    // 조회
+    public List<SearchRankUpStandard> searchRankUpStandard(Long userId, boolean userTypeCheck) {
+
+        if (userTypeCheck) {
+            userTypeCheckService.userTypeAdmin(userId);
+        }
+
+        List<SearchRankUpStandard> infoRankUpStandards = new ArrayList<>();
+
+        for (RankUpStandard rankUpStandard : rankUpStandardRepository.findAllByOrderByRankName()) {
+            SearchRankUpStandard searchRankUpStandard = SearchRankUpStandard.builder()
+                .standardId(rankUpStandard.getStandardId())
+                .rankName(rankUpStandard.getRankName())
+                .boardCount(rankUpStandard.getBoardCount())
+                .commentCount(rankUpStandard.getCommentCount())
+                .autoRankUpFlag(rankUpStandard.isAutoRankUpFlag())
+                .build();
+
+            infoRankUpStandards.add(searchRankUpStandard);
+        }
+
+        return infoRankUpStandards;
+    }
+
+
+    // 저장
+    @Transactional
+    public List<SearchRankUpStandard> addRankUpStandard(
+        Long userId, AddRankUpStandard addRankUpStandard) {
+
+        if (rankUpStandardRepository.existsByRankName(addRankUpStandard.getRankName())) {
+            throw new GlobalException(ALREADY_RANK);
+        } else if (addRankUpStandard.getRankName().equals(ADMIN)) {
+            throw new GlobalException(NOT_ADD_RANK);
+        }
+
+        // 입력 받은 등급의 전후 등급 확인
+        checkUnderOverRank(addRankUpStandard.getRankName(), addRankUpStandard.getBoardCount(),
+            addRankUpStandard.getCommentCount());
+
+        User user = userTypeCheckService.userTypeAdmin(userId);
+
+        RankUpStandard rankUpStandard = addRankUpStandard.save(addRankUpStandard);
+        user.getRankUpStandards().add(rankUpStandard);
+
+        return searchRankUpStandard(userId, false);
+    }
+
+
+    // 수정
+    @Transactional
+    public List<SearchRankUpStandard> modifyRankUpStandard(
+        Long userId, Long standardId, ModifyRankUpStandard modifyRankUpStandard) {
+
+        User user = userTypeCheckService.userTypeAdmin(userId);
+
+        RankUpStandard rankUpStandard = rankUpStandardRepository.findByStandardId(standardId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_RANK));
+
+        // 입력 받은 등급의 전후 등급 확인
+        checkUnderOverRank(rankUpStandard.getRankName(), rankUpStandard.getBoardCount(),
+            rankUpStandard.getCommentCount());
+
+        rankUpStandard.setBoardCount(modifyRankUpStandard.getBoardCount());
+        rankUpStandard.setCommentCount(modifyRankUpStandard.getCommentCount());
+        rankUpStandard.setAutoRankUpFlag(modifyRankUpStandard.isAutoRankUpFlag());
+        user.getRankUpStandards().add(rankUpStandard);
+
+        return searchRankUpStandard(userId, false);
+    }
+
+
+    // 삭제
+    @Transactional
+    public List<SearchRankUpStandard> deleteRankUpStandard(Long userId, Long standardId) {
+
+        userTypeCheckService.userTypeAdmin(userId);
+
+        RankUpStandard rankUpStandard = rankUpStandardRepository.findByStandardId(standardId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_RANK));
+
+        rankUpStandardRepository.delete(rankUpStandard);
+
+        return searchRankUpStandard(userId, false);
+    }
+
+
+    // 입력 받은 등급의 전후 등급 확인
+    public void checkUnderOverRank(RankType rankType, Long BoardCount, Long CommentCount) {
+
+        // 입력 받은 등급 보다 작은 등급 중 가장 높은 등급 조회
+        RankUpStandard underRank =
+            rankUpStandardRepository.findTop1ByRankNameLessThanOrderByRankNameDesc(rankType)
+                .orElse(null);
+
+        if (underRank != null &&
+            (underRank.getBoardCount() >= BoardCount ||
+                underRank.getCommentCount() >= CommentCount)) {
+            throw new GlobalException(UNDER_RANK_CHECK_BOARD_COMMENT);
+        }
+
+        // 입력 받은 등급 보다 큰 등급 중 가장 낮은 등급 조회
+        RankUpStandard overRank =
+            rankUpStandardRepository.findTop1ByRankNameGreaterThanOrderByRankName(rankType)
+                .orElse(null);
+
+        if (overRank != null &&
+            (overRank.getBoardCount() <= BoardCount ||
+                overRank.getCommentCount() <= CommentCount)) {
+            throw new GlobalException(OVER_RANK_CHECK_BOARD_COMMENT);
+        }
+    }
+}

--- a/src/main/java/com/example/board/service/impl/RankUpStandardImpl.java
+++ b/src/main/java/com/example/board/service/impl/RankUpStandardImpl.java
@@ -7,11 +7,11 @@ import static com.example.board.exception.ErrorCode.NOT_FIND_RANK;
 import static com.example.board.exception.ErrorCode.OVER_RANK_CHECK_BOARD_COMMENT;
 import static com.example.board.exception.ErrorCode.UNDER_RANK_CHECK_BOARD_COMMENT;
 
-import com.example.board.domain.dto.RankUpStandardDto.AddRankUpStandard;
-import com.example.board.domain.dto.RankUpStandardDto.ModifyRankUpStandard;
 import com.example.board.domain.dto.RankUpStandardDto.SearchRankUpStandard;
 import com.example.board.domain.entity.RankUpStandard;
 import com.example.board.domain.entity.User;
+import com.example.board.domain.form.RankUpStandardForm.AddRankUpStandard;
+import com.example.board.domain.form.RankUpStandardForm.ModifyRankUpStandard;
 import com.example.board.domain.repository.RankUpStandardRepository;
 import com.example.board.domain.type.RankType;
 import com.example.board.exception.GlobalException;
@@ -33,11 +33,7 @@ public class RankUpStandardImpl implements RankUpStandardService {
 
 
     // 조회
-    public List<SearchRankUpStandard> searchRankUpStandard(Long userId, boolean userTypeCheck) {
-
-        if (userTypeCheck) {
-            userTypeCheckService.userTypeAdmin(userId);
-        }
+    public List<SearchRankUpStandard> searchRankUpStandard() {
 
         List<SearchRankUpStandard> infoRankUpStandards = new ArrayList<>();
 
@@ -64,7 +60,8 @@ public class RankUpStandardImpl implements RankUpStandardService {
 
         if (rankUpStandardRepository.existsByRankName(addRankUpStandard.getRankName())) {
             throw new GlobalException(ALREADY_RANK);
-        } else if (addRankUpStandard.getRankName().equals(ADMIN)) {
+        }
+        if (addRankUpStandard.getRankName().equals(ADMIN)) {
             throw new GlobalException(NOT_ADD_RANK);
         }
 
@@ -74,10 +71,16 @@ public class RankUpStandardImpl implements RankUpStandardService {
 
         User user = userTypeCheckService.userTypeAdmin(userId);
 
-        RankUpStandard rankUpStandard = addRankUpStandard.save(addRankUpStandard);
+        RankUpStandard rankUpStandard = RankUpStandard.builder()
+            .rankName(addRankUpStandard.getRankName())
+            .boardCount(addRankUpStandard.getBoardCount())
+            .commentCount(addRankUpStandard.getCommentCount())
+            .autoRankUpFlag(addRankUpStandard.isAutoRankUpFlag())
+            .build();
+
         user.getRankUpStandards().add(rankUpStandard);
 
-        return searchRankUpStandard(userId, false);
+        return searchRankUpStandard();
     }
 
 
@@ -100,7 +103,7 @@ public class RankUpStandardImpl implements RankUpStandardService {
         rankUpStandard.setAutoRankUpFlag(modifyRankUpStandard.isAutoRankUpFlag());
         user.getRankUpStandards().add(rankUpStandard);
 
-        return searchRankUpStandard(userId, false);
+        return searchRankUpStandard();
     }
 
 
@@ -115,7 +118,7 @@ public class RankUpStandardImpl implements RankUpStandardService {
 
         rankUpStandardRepository.delete(rankUpStandard);
 
-        return searchRankUpStandard(userId, false);
+        return searchRankUpStandard();
     }
 
 

--- a/src/main/java/com/example/board/service/impl/SignInServiceImpl.java
+++ b/src/main/java/com/example/board/service/impl/SignInServiceImpl.java
@@ -1,7 +1,5 @@
 package com.example.board.service.impl;
 
-import static com.example.board.exception.ErrorCode.BLANK_LOGIN_ID;
-import static com.example.board.exception.ErrorCode.BLANK_PASSWORD;
 import static com.example.board.exception.ErrorCode.NOT_FIND_LOGIN_ID;
 import static com.example.board.exception.ErrorCode.WRONG_LOGIN_PASSWORD;
 
@@ -27,15 +25,6 @@ public class SignInServiceImpl implements SignInService {
 
     // 로그인
     public String signIn(UserDto.SignIn signIn) {
-
-        // 입력값 확인
-        if (signIn.getLoginId().equals("")) {
-            throw new GlobalException(BLANK_LOGIN_ID);
-        }
-        if (signIn.getUserPassword().equals("")) {
-            throw new GlobalException(BLANK_PASSWORD);
-        }
-
         User user = userRepository.findByLoginId(signIn.getLoginId())
             .orElseThrow(() -> new GlobalException(NOT_FIND_LOGIN_ID));
 
@@ -43,6 +32,6 @@ public class SignInServiceImpl implements SignInService {
             throw new GlobalException(WRONG_LOGIN_PASSWORD);
         }
 
-        return tokenProvider.createToken(user.getLoginId(), user.getUserRank());
+        return tokenProvider.createToken(user.getUserId(), user.getLoginId(), user.getUserRank());
     }
 }

--- a/src/main/java/com/example/board/service/impl/SignInServiceImpl.java
+++ b/src/main/java/com/example/board/service/impl/SignInServiceImpl.java
@@ -3,8 +3,8 @@ package com.example.board.service.impl;
 import static com.example.board.exception.ErrorCode.NOT_FIND_LOGIN_ID;
 import static com.example.board.exception.ErrorCode.WRONG_LOGIN_PASSWORD;
 
-import com.example.board.domain.dto.UserDto;
 import com.example.board.domain.entity.User;
+import com.example.board.domain.form.UserForm.SignIn;
 import com.example.board.domain.repository.UserRepository;
 import com.example.board.exception.GlobalException;
 import com.example.board.security.TokenProvider;
@@ -24,7 +24,8 @@ public class SignInServiceImpl implements SignInService {
 
 
     // 로그인
-    public String signIn(UserDto.SignIn signIn) {
+    public String signIn(SignIn signIn) {
+
         User user = userRepository.findByLoginId(signIn.getLoginId())
             .orElseThrow(() -> new GlobalException(NOT_FIND_LOGIN_ID));
 

--- a/src/main/java/com/example/board/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/com/example/board/service/impl/SignUpServiceImpl.java
@@ -3,8 +3,10 @@ package com.example.board.service.impl;
 import static com.example.board.exception.ErrorCode.ALREADY_LOGIN_ID;
 import static com.example.board.exception.ErrorCode.ALREADY_NICK_NAME;
 
-import com.example.board.domain.dto.UserDto;
+import com.example.board.domain.entity.User;
+import com.example.board.domain.form.UserForm.SignUp;
 import com.example.board.domain.repository.UserRepository;
+import com.example.board.domain.type.RankType;
 import com.example.board.domain.type.UserType;
 import com.example.board.exception.GlobalException;
 import com.example.board.service.SignUpService;
@@ -24,7 +26,8 @@ public class SignUpServiceImpl implements SignUpService {
 
     // 회원가입
     @Transactional
-    public String signUp(UserDto.SignUp signUp, UserType userType) {
+    public String signUp(SignUp signUp, UserType userType) {
+
         // 아이디 확인
         if (userRepository.existsByLoginId(signUp.getLoginId())) {
             throw new GlobalException(ALREADY_LOGIN_ID);
@@ -35,8 +38,13 @@ public class SignUpServiceImpl implements SignUpService {
             throw new GlobalException(ALREADY_NICK_NAME);
         }
 
-        signUp.setUserPassword(passwordEncoder.encode(signUp.getUserPassword()));
-        userRepository.save(signUp.save(signUp, userType));
+        userRepository.save(
+            User.builder()
+                .loginId(signUp.getLoginId())
+                .userNickName(signUp.getUserNickName())
+                .userPassword(passwordEncoder.encode(signUp.getUserPassword()))
+                .userRank(userType.equals(UserType.USER) ? RankType.LEVEL1 : RankType.ADMIN)
+                .build());
 
         return "회원가입이 완료 되었습니다.";
     }

--- a/src/main/java/com/example/board/service/impl/UserTypeCheckServiceImpl.java
+++ b/src/main/java/com/example/board/service/impl/UserTypeCheckServiceImpl.java
@@ -1,0 +1,32 @@
+package com.example.board.service.impl;
+
+import static com.example.board.domain.type.RankType.ADMIN;
+import static com.example.board.exception.ErrorCode.NOT_FIND_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.NOT_MATCH_USER_RANK;
+
+import com.example.board.domain.entity.User;
+import com.example.board.domain.repository.UserRepository;
+import com.example.board.exception.GlobalException;
+import com.example.board.service.UserTypeCheckService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserTypeCheckServiceImpl implements UserTypeCheckService {
+
+    private final UserRepository userRepository;
+
+
+    public User userTypeAdmin(Long userId) {
+        User user = userRepository.findByUserId(userId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_LOGIN_ID));
+
+        if (!user.getUserRank().equals(ADMIN)) {
+            throw new GlobalException(NOT_MATCH_USER_RANK);
+        }
+
+        return user;
+    }
+}


### PR DESCRIPTION
### FEAT : RankUpStandard(등업 기준) 기능 추가

**AS-IS**
1. 등업 기준
    (1) 각 등업 기준을 등록한다.
    (2) 게시글, 댓글 등록 시 자동 등업 여부에 따라 자동으로 등업을 시키거나 관리자가 확인 후 등업 시킨다.

**TO-BE**
1. 등업기준
    - [x] 각 등업 기준을 등록한다. (CRUD 추가)
    - [ ]  게시글, 댓글 등록 시 자동 등업 여부에 따라 자동으로 등업을 시키거나 관리자가 확인 후 등업 시킨다.

2. 토큰
    (1) 유효성 검사 추가
    
### FeedBack

**AS-IS**
1. 등업 기준
    (1) 조회 boolean 제외 후 관리자, 사용자 따로 나눌 수 있도록 로직 수정
    (2) RankUpStandardDto에서 빌더로 entity 생성을 service로 이동
    (3) 저장 시 예외 체크 따로 분리

**TO-BE**
1. 등업 기준
    - [x] 조회 boolean 제외 후 관리자, 사용자 따로 나눌 수 있도록 로직 수정 (관리자, 사용자 조회 가능)
    - [x] RankUpStandardDto에서 빌더로 entity 생성을 service로 이동
    - [x] 저장 시 예외 체크 따로 분리
2. 회원가입
    (1) 등업 기준 리뷰에서 나온 Dto 빌더 내용 service에서 처리
3. dto 와 form 분리    

### 테스트
1. scratch_user.http 를 통한 회원 가입 및 로그인 진행
2. scratch_rankupstandard.http  를 생성하여 등업 기준 CRUD 테스트