### PR TITLE
[010-FEAT] : Board

### DIFF
--- a/scratch_board.http
+++ b/scratch_board.http
@@ -1,0 +1,47 @@
+### 게시글 목록 조회
+GET http://localhost:8080/board/list/0/10
+Content-Type: application/json
+USER_TOKEN_HEADER:
+
+{
+  "boardTitle": "",
+  "nickName": ""
+}
+
+
+### 게시글 조회
+GET http://localhost:8080/board/content/1/36
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTQyNjI0OSwiZXhwIjoxNjg1NTEyNjQ5fQ.rNQUcYw6_t82VIDXWeiXlaYNyVrXD4RO_XXkJLgwIVNzZ1TvNMPx0fKgEdJosvWpmAcPSn8QAShVEP59Y9mjtw
+
+
+### 게시글 저장
+POST http://localhost:8080/board/add
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTQyNTE3NiwiZXhwIjoxNjg1NTExNTc2fQ.ae17zVl-YgeuzODco903mtzdM568IIhp75x9_L0TvpPzzdkE5ymhLsh8SnksJgTHcgTQ8gSe2Te1rUdQVkpXHw
+
+{
+  "categoryId": 1,
+  "boardTitle": "하파타카차자아사바마라다나가",
+  "boardContent": "에헤 오에오에오오오~",
+  "boardPublicFlag": true
+}
+
+
+### 게시글 수정
+PUT http://localhost:8080/board/modify/39
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTQyNTE3NiwiZXhwIjoxNjg1NTExNTc2fQ.ae17zVl-YgeuzODco903mtzdM568IIhp75x9_L0TvpPzzdkE5ymhLsh8SnksJgTHcgTQ8gSe2Te1rUdQVkpXHw
+
+{
+  "categoryId": 1,
+  "boardTitle": "22222",
+  "boardContent": "하나둘셋넷다섯여섯일곱",
+  "boardPublicFlag": true
+}
+
+
+### 게시글 삭제
+DELETE http://localhost:8080/board/delete/35
+Content-Type: application/json
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTM3MjYzMiwiZXhwIjoxNjg1NDU5MDMyfQ.w2Peltz6TmUpu5xEmGDu68Ax848Ndsz19Xicg_G3krCOrkbxbRCLOo37BeZiGmXy6QU9zXVsSYAEFnR8cctr-Q

--- a/scratch_board.http
+++ b/scratch_board.http
@@ -1,24 +1,35 @@
 ### 게시글 목록 조회
-GET http://localhost:8080/board/list/0/10
+GET http://localhost:8080/board/list
 Content-Type: application/json
-USER_TOKEN_HEADER:
+//USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTUyNjYxNCwiZXhwIjoxNjg1NjEzMDE0fQ.xUEy6_Ha42Rp0MOWT1nZKKKkBnBL65y62T9i6VSQKTOiBouqSyBle1oagCaeQy1yndoy7_6u_rdjwDbrGYsiaQ
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJ1WXVtTmUxSHlCR2hHRVFubXEvYVN3PT0iLCJzdWIiOiJlbWhSYWNpbFRSNFRlTTJyQ3B2Wml3PT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTU0NjEyMiwiZXhwIjoxNjg1NjMyNTIyfQ.BNevBKrSjGInq54_LBHIu3a_N2V2umFNwKOk1cffzNje-1tzV-xQ0ip8GTOWEtjyttlbNr3xzzSA73f4fVxpww
+
 
 {
+  "page" : 0,
+  "size": 20,
+  "categoryId" : 0,
   "boardTitle": "",
   "nickName": ""
 }
 
 
 ### 게시글 조회
-GET http://localhost:8080/board/content/1/36
+GET http://localhost:8080/board/content
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTQyNjI0OSwiZXhwIjoxNjg1NTEyNjQ5fQ.rNQUcYw6_t82VIDXWeiXlaYNyVrXD4RO_XXkJLgwIVNzZ1TvNMPx0fKgEdJosvWpmAcPSn8QAShVEP59Y9mjtw
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTUyNjYxNCwiZXhwIjoxNjg1NjEzMDE0fQ.xUEy6_Ha42Rp0MOWT1nZKKKkBnBL65y62T9i6VSQKTOiBouqSyBle1oagCaeQy1yndoy7_6u_rdjwDbrGYsiaQ
+
+{
+  "categoryId" : 1,
+  "boardId": 36
+}
+
 
 
 ### 게시글 저장
-POST http://localhost:8080/board/add
+POST http://localhost:8080/board/content
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTQyNTE3NiwiZXhwIjoxNjg1NTExNTc2fQ.ae17zVl-YgeuzODco903mtzdM568IIhp75x9_L0TvpPzzdkE5ymhLsh8SnksJgTHcgTQ8gSe2Te1rUdQVkpXHw
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTUyNjYxNCwiZXhwIjoxNjg1NjEzMDE0fQ.xUEy6_Ha42Rp0MOWT1nZKKKkBnBL65y62T9i6VSQKTOiBouqSyBle1oagCaeQy1yndoy7_6u_rdjwDbrGYsiaQ
 
 {
   "categoryId": 1,
@@ -29,9 +40,9 @@ USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3
 
 
 ### 게시글 수정
-PUT http://localhost:8080/board/modify/39
+PUT http://localhost:8080/board/content/39
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTQyNTE3NiwiZXhwIjoxNjg1NTExNTc2fQ.ae17zVl-YgeuzODco903mtzdM568IIhp75x9_L0TvpPzzdkE5ymhLsh8SnksJgTHcgTQ8gSe2Te1rUdQVkpXHw
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJ1WXVtTmUxSHlCR2hHRVFubXEvYVN3PT0iLCJzdWIiOiJlbWhSYWNpbFRSNFRlTTJyQ3B2Wml3PT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTU0NjEyMiwiZXhwIjoxNjg1NjMyNTIyfQ.BNevBKrSjGInq54_LBHIu3a_N2V2umFNwKOk1cffzNje-1tzV-xQ0ip8GTOWEtjyttlbNr3xzzSA73f4fVxpww
 
 {
   "categoryId": 1,
@@ -42,6 +53,6 @@ USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3
 
 
 ### 게시글 삭제
-DELETE http://localhost:8080/board/delete/35
+DELETE http://localhost:8080/board/content/39
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJCc1hpbUpGQVRBbWwvYzhVdkF1KzB3PT0iLCJzdWIiOiI2RzZzeThTZVZBS0xseithNEN0RlJnPT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTM3MjYzMiwiZXhwIjoxNjg1NDU5MDMyfQ.w2Peltz6TmUpu5xEmGDu68Ax848Ndsz19Xicg_G3krCOrkbxbRCLOo37BeZiGmXy6QU9zXVsSYAEFnR8cctr-Q
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJ1WXVtTmUxSHlCR2hHRVFubXEvYVN3PT0iLCJzdWIiOiJlbWhSYWNpbFRSNFRlTTJyQ3B2Wml3PT0iLCJyb2xlcyI6IkxFVkVMMSIsImlhdCI6MTY4NTU0NjEyMiwiZXhwIjoxNjg1NjMyNTIyfQ.BNevBKrSjGInq54_LBHIu3a_N2V2umFNwKOk1cffzNje-1tzV-xQ0ip8GTOWEtjyttlbNr3xzzSA73f4fVxpww

--- a/scratch_category.http
+++ b/scratch_category.http
@@ -6,11 +6,11 @@ Content-Type: application/json
 ### 게시판 분류 저장
 POST http://localhost:8080/category/add
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg1MTk5MDM1LCJleHAiOjE2ODUyODU0MzV9.Wb4FxIj3UDxUpq0BxBCjudvtKC7mJPuX0puvr8rdLAaBl2gjrquWGRP0lQn4S_GmU12Q-ydvNlXXLW7jrOe2kg
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg1MjgzOTA1LCJleHAiOjE2ODUzNzAzMDV9.bav2cFioyfq2i7vlH1S3jCqwBXPlmV0_95Y5xkbGvOPXvSyblqDYAAFKemDRaQXuNGz08Xiw55W0h8ureTUlZQ
 
 {
   "categoryTitle": "렙 1",
-  "categoryRank": "LEVEL4",
+  "categoryRank": "LEVEL1",
   "categoryUesFlag": true
 }
 

--- a/scratch_rankupstandard.http
+++ b/scratch_rankupstandard.http
@@ -6,12 +6,12 @@ Content-Type: application/json
 ### 등업 기준 저장
 POST http://localhost:8080/rankup/add
 Content-Type: application/json
-USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg1MTk5ODMwLCJleHAiOjE2ODUyODYyMzB9.ph3WgddRzo9NgxW0fXNuplaNVOOPjn9gCphkXujMBEbguckh93pQ3fXM11GTiPkIAmNhMhUfb7lmIp0IhJU7KQ
+USER_TOKEN_HEADER: eyJhbGciOiJIUzUxMiJ9.eyJqdGkiOiJFc2hIUnZsbHk1SitpeDEwLzJTWGxRPT0iLCJzdWIiOiJwdjVwQzNUOElkQTd3UncvbFZLcE13PT0iLCJyb2xlcyI6IkFETUlOIiwiaWF0IjoxNjg1MjgzOTA1LCJleHAiOjE2ODUzNzAzMDV9.bav2cFioyfq2i7vlH1S3jCqwBXPlmV0_95Y5xkbGvOPXvSyblqDYAAFKemDRaQXuNGz08Xiw55W0h8ureTUlZQ
 
 {
-  "rankName": "LEVEL4",
-  "boardCount": 15,
-  "commentCount": 15,
+  "rankName": "LEVEL1",
+  "boardCount": 0,
+  "commentCount": 0,
   "autoRankUpFlag": true
 }
 

--- a/scratch_sign.http
+++ b/scratch_sign.http
@@ -14,9 +14,9 @@ POST http://localhost:8080/signup/user
 Content-Type: application/json
 
 {
-  "loginId": "ohdonggeon",
-  "userNickName": "먼지제거제",
-  "userPassword": "zxcvbnm123@"
+  "loginId": "ohdonggeon2",
+  "userNickName": "먼지제거제2",
+  "userPassword": "abcdefgh1!"
 }
 
 
@@ -25,6 +25,6 @@ POST http://localhost:8080/signin
 Content-Type: application/json
 
 {
-  "loginId": "administrator",
+  "loginId": "ohdonggeon",
   "userPassword": "abcdefgh1!"
 }

--- a/src/main/java/com/example/board/controller/BoardController.java
+++ b/src/main/java/com/example/board/controller/BoardController.java
@@ -1,0 +1,90 @@
+package com.example.board.controller;
+
+import com.example.board.domain.dto.BoardDto.SearchContentBoard;
+import com.example.board.domain.dto.BoardDto.SearchListBoard;
+import com.example.board.domain.form.BoardForm.ListBoard;
+import com.example.board.domain.form.BoardForm.MergeBoard;
+import com.example.board.security.TokenProvider;
+import com.example.board.service.BoardService;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/board")
+public class BoardController {
+
+    private final BoardService boardService;
+    private final TokenProvider tokenProvider;
+    public final String TOKEN_HEADER = "USER_TOKEN_HEADER";
+
+
+    // 게시판 목록 조회
+    @GetMapping("/list/{page}/{size}")
+    public ResponseEntity<List<SearchListBoard>> searchListBoard(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @PathVariable("page") int page, @PathVariable("size") int size,
+        @RequestBody @Valid ListBoard listBoard) {
+
+        return ResponseEntity.ok(boardService.searchListBoard(
+            tokenProvider.getTokenUserId(token), page, size, listBoard));
+    }
+
+
+    // 게시판 내용 조회
+    @GetMapping("/content/{categoryId}/{boardId}")
+    public ResponseEntity<SearchContentBoard> searchContentBoard(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @PathVariable("categoryId") Long categoryId,
+        @PathVariable("boardId") Long boardId) {
+
+        return ResponseEntity.ok(boardService.searchContentBoard(
+            tokenProvider.getTokenUserId(token), categoryId, boardId));
+    }
+
+
+    // 저장
+    @PostMapping("/add")
+    public ResponseEntity<SearchContentBoard> addBoard(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @RequestBody @Valid MergeBoard mergeBoard) {
+
+        return ResponseEntity.ok(boardService.addBoard(
+            tokenProvider.getTokenUserId(token), mergeBoard));
+    }
+
+
+    // 수정
+    @PutMapping("/modify/{boardId}")
+    public ResponseEntity<SearchContentBoard> modifyBoard(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @PathVariable("boardId") Long boardId,
+        @RequestBody @Valid MergeBoard mergeBoard) {
+
+        return ResponseEntity.ok(boardService.modifyBoard(
+            tokenProvider.getTokenUserId(token), boardId, mergeBoard));
+    }
+
+
+    // 삭제
+    @DeleteMapping("/delete/{boardId}")
+    public ResponseEntity<List<SearchListBoard>> deleteCategory(
+        @RequestHeader(name = TOKEN_HEADER) String token,
+        @PathVariable("boardId") Long boardId) {
+
+        return ResponseEntity.ok(boardService.deleteBoard(
+            tokenProvider.getTokenUserId(token), boardId));
+    }
+}

--- a/src/main/java/com/example/board/controller/BoardController.java
+++ b/src/main/java/com/example/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.example.board.controller;
 
 import com.example.board.domain.dto.BoardDto.SearchContentBoard;
 import com.example.board.domain.dto.BoardDto.SearchListBoard;
+import com.example.board.domain.form.BoardForm.ContentBoard;
 import com.example.board.domain.form.BoardForm.ListBoard;
 import com.example.board.domain.form.BoardForm.MergeBoard;
 import com.example.board.security.TokenProvider;
@@ -32,31 +33,29 @@ public class BoardController {
 
 
     // 게시판 목록 조회
-    @GetMapping("/list/{page}/{size}")
+    @GetMapping("list")
     public ResponseEntity<List<SearchListBoard>> searchListBoard(
         @RequestHeader(name = TOKEN_HEADER) String token,
-        @PathVariable("page") int page, @PathVariable("size") int size,
         @RequestBody @Valid ListBoard listBoard) {
 
         return ResponseEntity.ok(boardService.searchListBoard(
-            tokenProvider.getTokenUserId(token), page, size, listBoard));
+            tokenProvider.getTokenUserId(token), listBoard));
     }
 
 
     // 게시판 내용 조회
-    @GetMapping("/content/{categoryId}/{boardId}")
+    @GetMapping("/content")
     public ResponseEntity<SearchContentBoard> searchContentBoard(
         @RequestHeader(name = TOKEN_HEADER) String token,
-        @PathVariable("categoryId") Long categoryId,
-        @PathVariable("boardId") Long boardId) {
+        @RequestBody @Valid ContentBoard contentBoard) {
 
         return ResponseEntity.ok(boardService.searchContentBoard(
-            tokenProvider.getTokenUserId(token), categoryId, boardId));
+            tokenProvider.getTokenUserId(token), contentBoard));
     }
 
 
     // 저장
-    @PostMapping("/add")
+    @PostMapping("/content")
     public ResponseEntity<SearchContentBoard> addBoard(
         @RequestHeader(name = TOKEN_HEADER) String token,
         @RequestBody @Valid MergeBoard mergeBoard) {
@@ -67,7 +66,7 @@ public class BoardController {
 
 
     // 수정
-    @PutMapping("/modify/{boardId}")
+    @PutMapping("/content/{boardId}")
     public ResponseEntity<SearchContentBoard> modifyBoard(
         @RequestHeader(name = TOKEN_HEADER) String token,
         @PathVariable("boardId") Long boardId,
@@ -79,7 +78,7 @@ public class BoardController {
 
 
     // 삭제
-    @DeleteMapping("/delete/{boardId}")
+    @DeleteMapping("/content/{boardId}")
     public ResponseEntity<List<SearchListBoard>> deleteCategory(
         @RequestHeader(name = TOKEN_HEADER) String token,
         @PathVariable("boardId") Long boardId) {

--- a/src/main/java/com/example/board/domain/dto/BoardDto.java
+++ b/src/main/java/com/example/board/domain/dto/BoardDto.java
@@ -11,6 +11,19 @@ import lombok.Setter;
 
 public class BoardDto {
 
+    // interface projection 쿼리의 데이터를 받아옴 Alias(AS) 을 사용하여 칼럼명 맞춰줘야 함
+    // class projection 를 시도 해보았지만 이너 클래스에선 간편하게 되질 않았음 따로 Dto 를 나눠야 했고,
+    // Select 시 Dto 위치를 지정해 줘야 했음
+    // ex) select new com.example.board.domain.dto(칼럼명) from 테이블
+    public interface SearchList {
+        Long getBoardId();
+        String getBoardTitle();
+        Long getUserId();
+        String getUserNickName();
+        LocalDateTime getCreateDate();
+    }
+
+
     @Getter
     @Setter
     @Builder
@@ -37,6 +50,8 @@ public class BoardDto {
 
         private Long userId;
         private String userNickName;
+        private Long categoryId;
+        private String categoryTitle;
         private Long boardId;
         private String boardTitle;
         private String boardContent;

--- a/src/main/java/com/example/board/domain/dto/BoardDto.java
+++ b/src/main/java/com/example/board/domain/dto/BoardDto.java
@@ -1,0 +1,47 @@
+package com.example.board.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+public class BoardDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchListBoard {
+
+        private Long boardId;
+        private String boardTitle;
+        private Long userId;
+        private String userNickName;
+        @JsonFormat(shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime createDate;
+    }
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchContentBoard {
+
+        private Long userId;
+        private String userNickName;
+        private Long boardId;
+        private String boardTitle;
+        private String boardContent;
+        @JsonFormat(shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime createDate;
+    }
+}

--- a/src/main/java/com/example/board/domain/entity/Board.java
+++ b/src/main/java/com/example/board/domain/entity/Board.java
@@ -1,19 +1,12 @@
 package com.example.board.domain.entity;
 
-import com.example.board.domain.type.RankType;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,25 +22,23 @@ import org.hibernate.envers.AuditOverride;
 @AllArgsConstructor
 @NoArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
-public class Category extends BaseEntity {
+public class Board extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long categoryId;
+    private Long boardId;
 
-    @Column(columnDefinition = "VARCHAR(20) NOT NULL")
-    private String categoryTitle;
-    @Column(columnDefinition = "VARCHAR(10) NOT NULL")
-    @Enumerated(EnumType.STRING)
-    private RankType categoryRank;
-    private boolean categoryUesFlag;
+    @Column(columnDefinition = "VARCHAR(100) NOT NULL")
+    private String boardTitle;
+    private String boardContent;
+    private boolean boardPublicFlag;
 
 
     @ManyToOne
-    @JoinColumn(name = "createdUserId")
+    @JoinColumn(name = "userId")
     private User user;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "categoryId")
-    private List<Board> boards = new ArrayList<>();
+    private Category category;
 }

--- a/src/main/java/com/example/board/domain/entity/User.java
+++ b/src/main/java/com/example/board/domain/entity/User.java
@@ -50,4 +50,8 @@ public class User extends BaseEntity {
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "createdUserId")
     private List<Category> categories = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "userId")
+    private List<Board> boards = new ArrayList<>();
 }

--- a/src/main/java/com/example/board/domain/form/BoardForm.java
+++ b/src/main/java/com/example/board/domain/form/BoardForm.java
@@ -19,8 +19,23 @@ public class BoardForm {
     @AllArgsConstructor
     public static class ListBoard {
 
+        private int page;
+        private int size;
+        private Long categoryId;
         private String boardTitle;
         private String nickName;
+    }
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContentBoard {
+
+        private Long categoryId;
+        private Long boardId;
     }
 
 

--- a/src/main/java/com/example/board/domain/form/BoardForm.java
+++ b/src/main/java/com/example/board/domain/form/BoardForm.java
@@ -1,0 +1,43 @@
+package com.example.board.domain.form;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+public class BoardForm {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ListBoard {
+
+        private String boardTitle;
+        private String nickName;
+    }
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MergeBoard {
+
+        @NotNull(message = "게시판 분류를 선택하세요.")
+        private Long categoryId;
+        @NotBlank(message = "게시글 제목을 입력하세요.")
+        @Size(min = 5, max = 100, message = "게시글 제목은 5자 이상 100자 이하입니다.")
+        private String boardTitle;
+        @NotBlank(message = "게시글을 입력하세요.")
+        private String boardContent;
+        private boolean boardPublicFlag;
+    }
+}

--- a/src/main/java/com/example/board/domain/repository/BoardRepository.java
+++ b/src/main/java/com/example/board/domain/repository/BoardRepository.java
@@ -1,5 +1,6 @@
 package com.example.board.domain.repository;
 
+import com.example.board.domain.dto.BoardDto.SearchList;
 import com.example.board.domain.entity.Board;
 import java.util.List;
 import java.util.Optional;
@@ -12,13 +13,30 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    @Query(value = "SELECT bo.boardId, bo.boardTitle, bo.user.userId "
-                 + "     , bo.user.userNickName , bo.createDate "
+    @Query(value = "SELECT bo.boardId               AS boardId "
+                 + "     , bo.boardTitle            AS boardTitle "
+                 + "     , bo.user.userId           AS userId "
+                 + "     , bo.user.userNickName     AS userNickName "
+                 + "     , bo.createDate            AS createDate "
                  + "  FROM Board bo "
-                 + " WHERE (bo.user.userId = :userId    OR bo.boardPublicFlag = true) "
-                 + "   AND bo.boardTitle LIKE %:title% "
+                 + " WHERE (bo.user.userId      = :userId "
+                 + "    OR bo.boardPublicFlag   = true) "
+                 + "   AND bo.boardTitle        LIKE %:title% "
                  + "   AND bo.user.userNickName LIKE %:nickName%")
-    List<Object[]> findBoardList(Long userId, String title, String nickName, Pageable pageable);
+    List<SearchList> findAllBoardList(Long userId, String title, String nickName, Pageable pageable);
+
+    @Query(value = "SELECT bo.boardId               AS boardId "
+                 + "     , bo.boardTitle            AS boardTitle "
+                 + "     , bo.user.userId           AS userId "
+                 + "     , bo.user.userNickName     AS userNickName "
+                 + "     , bo.createDate            AS createDate "
+                 + "  FROM Board bo "
+                 + " WHERE (bo.user.userId          = :userId "
+                 + "    OR bo.boardPublicFlag       = true) "
+                 + "   AND bo.category.categoryId   = :categoryId "
+                 + "   AND bo.boardTitle            LIKE %:title% "
+                 + "   AND bo.user.userNickName     LIKE %:nickName%")
+    List<SearchList> findBoardList(Long userId, Long categoryId, String title, String nickName, Pageable pageable);
 
     Optional<Board> findByBoardId(Long boardId);
 

--- a/src/main/java/com/example/board/domain/repository/BoardRepository.java
+++ b/src/main/java/com/example/board/domain/repository/BoardRepository.java
@@ -1,0 +1,25 @@
+package com.example.board.domain.repository;
+
+import com.example.board.domain.entity.Board;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    @Query(value = "SELECT bo.boardId, bo.boardTitle, bo.user.userId "
+                 + "     , bo.user.userNickName , bo.createDate "
+                 + "  FROM Board bo "
+                 + " WHERE (bo.user.userId = :userId    OR bo.boardPublicFlag = true) "
+                 + "   AND bo.boardTitle LIKE %:title% "
+                 + "   AND bo.user.userNickName LIKE %:nickName%")
+    List<Object[]> findBoardList(Long userId, String title, String nickName, Pageable pageable);
+
+    Optional<Board> findByBoardId(Long boardId);
+
+}

--- a/src/main/java/com/example/board/exception/ErrorCode.java
+++ b/src/main/java/com/example/board/exception/ErrorCode.java
@@ -11,9 +11,6 @@ public enum ErrorCode {
     // 회원 관련
     ALREADY_LOGIN_ID("이미 사용중인 아이디 입니다."),
     ALREADY_NICK_NAME("이미 사용중인 닉네임 입니다."),
-
-
-    // 로그인
     NOT_FIND_LOGIN_ID("존재하지 않는 아이디 입니다."),
     WRONG_LOGIN_PASSWORD("비밀번호가 일치하지 않습니다."),
 
@@ -30,7 +27,12 @@ public enum ErrorCode {
 
     // 게시판 분류 관련
     REGISTERED_RANK_CATEGORY("해당 등급에 등록된 게시판 분류가 있습니다."),
-    NOT_FIND_CATEGORY("존재하지 않는 게시판 분류 입니다.");
+    NOT_FIND_CATEGORY("존재하지 않는 게시판 분류 입니다."),
+
+    // 게시글
+    NOT_FIND_BOARD("존재하지 않는 게시글 입니다."),
+    NOT_MATCH_LOGIN_ID("게시글의 작성자가 아닙니다."),
+    CLOSED_BOARD("비공개 게시글 입니다.");
 
 
     private final String MESSAGE;

--- a/src/main/java/com/example/board/security/TokenProvider.java
+++ b/src/main/java/com/example/board/security/TokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.StringUtils;
 
 
 public class TokenProvider {
@@ -35,6 +36,9 @@ public class TokenProvider {
 
 
     public Long getTokenUserId(String token) {
+        if (!StringUtils.hasText(token)) {
+            return 0L;
+        }
         Claims claims = parseClaims(token);
         return Long.valueOf(Objects.requireNonNull(Aes256util.decrypt(claims.getId())));
     }

--- a/src/main/java/com/example/board/security/TokenProvider.java
+++ b/src/main/java/com/example/board/security/TokenProvider.java
@@ -16,6 +16,7 @@ public class TokenProvider {
     @Value("${spring.jwt.secret}")
     private String secretKey;
     private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;
+    private static final long EMPTY_TOKEN_USERID = 0;
 
 
     public String createToken(Long userId, String loginId, RankType userRank) {
@@ -37,7 +38,7 @@ public class TokenProvider {
 
     public Long getTokenUserId(String token) {
         if (!StringUtils.hasText(token)) {
-            return 0L;
+            return EMPTY_TOKEN_USERID;
         }
         Claims claims = parseClaims(token);
         return Long.valueOf(Objects.requireNonNull(Aes256util.decrypt(claims.getId())));

--- a/src/main/java/com/example/board/security/filter/TokenFilter.java
+++ b/src/main/java/com/example/board/security/filter/TokenFilter.java
@@ -16,7 +16,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 @WebFilter(urlPatterns = {
     "/rankup/add/*", "/rankup/modify/*", "/rankup/delete/*",
-    "/category/add/*", "/category/modify/*", "/category/delete/*"
+    "/category/add/*", "/category/modify/*", "/category/delete/*",
+    "/board/*"
 })
 public class TokenFilter extends OncePerRequestFilter {
 
@@ -30,6 +31,12 @@ public class TokenFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException {
 
         String token = request.getHeader(TOKEN_HEADER);
+        String requestURI = request.getRequestURI();
+
+        if (requestURI.startsWith("/board/list") && !StringUtils.hasText(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         if (!StringUtils.hasText(token) || !tokenProvider.validateToken(token)) {
             throw new ServletException("유효하지 않은 접근입니다.");

--- a/src/main/java/com/example/board/service/BoardService.java
+++ b/src/main/java/com/example/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.example.board.service;
 
 import com.example.board.domain.dto.BoardDto.SearchContentBoard;
 import com.example.board.domain.dto.BoardDto.SearchListBoard;
+import com.example.board.domain.form.BoardForm.ContentBoard;
 import com.example.board.domain.form.BoardForm.ListBoard;
 import com.example.board.domain.form.BoardForm.MergeBoard;
 import java.util.List;
@@ -10,10 +11,10 @@ import java.util.List;
 public interface BoardService {
 
     // 게시판 목록 조회
-    List<SearchListBoard> searchListBoard(Long userId, int page, int size, ListBoard listBoard);
+    List<SearchListBoard> searchListBoard(Long userId, ListBoard listBoard);
 
     // 게시판 내용 조회
-    SearchContentBoard searchContentBoard(Long userId, Long categoryId, Long boardId);
+    SearchContentBoard searchContentBoard(Long userId, ContentBoard contentBoard);
 
     // 저장
     SearchContentBoard addBoard(Long userId, MergeBoard mergeBoard);

--- a/src/main/java/com/example/board/service/BoardService.java
+++ b/src/main/java/com/example/board/service/BoardService.java
@@ -1,0 +1,26 @@
+package com.example.board.service;
+
+import com.example.board.domain.dto.BoardDto.SearchContentBoard;
+import com.example.board.domain.dto.BoardDto.SearchListBoard;
+import com.example.board.domain.form.BoardForm.ListBoard;
+import com.example.board.domain.form.BoardForm.MergeBoard;
+import java.util.List;
+
+
+public interface BoardService {
+
+    // 게시판 목록 조회
+    List<SearchListBoard> searchListBoard(Long userId, int page, int size, ListBoard listBoard);
+
+    // 게시판 내용 조회
+    SearchContentBoard searchContentBoard(Long userId, Long categoryId, Long boardId);
+
+    // 저장
+    SearchContentBoard addBoard(Long userId, MergeBoard mergeBoard);
+
+    // 수정
+    SearchContentBoard modifyBoard(Long userId, Long boardId, MergeBoard mergeBoard);
+
+    // 삭제
+    List<SearchListBoard> deleteBoard(Long userId, Long boardId);
+}

--- a/src/main/java/com/example/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/example/board/service/impl/BoardServiceImpl.java
@@ -1,0 +1,193 @@
+package com.example.board.service.impl;
+
+import static com.example.board.exception.ErrorCode.CLOSED_BOARD;
+import static com.example.board.exception.ErrorCode.NOT_FIND_BOARD;
+import static com.example.board.exception.ErrorCode.NOT_FIND_CATEGORY;
+import static com.example.board.exception.ErrorCode.NOT_FIND_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.NOT_MATCH_LOGIN_ID;
+import static com.example.board.exception.ErrorCode.NOT_MATCH_USER_RANK;
+
+import com.example.board.domain.dto.BoardDto;
+import com.example.board.domain.dto.BoardDto.SearchContentBoard;
+import com.example.board.domain.dto.BoardDto.SearchListBoard;
+import com.example.board.domain.entity.Board;
+import com.example.board.domain.entity.Category;
+import com.example.board.domain.entity.User;
+import com.example.board.domain.form.BoardForm.ListBoard;
+import com.example.board.domain.form.BoardForm.MergeBoard;
+import com.example.board.domain.repository.BoardRepository;
+import com.example.board.domain.repository.CategoryRepository;
+import com.example.board.domain.repository.UserRepository;
+import com.example.board.domain.type.RankType;
+import com.example.board.exception.GlobalException;
+import com.example.board.service.BoardService;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService {
+
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final BoardRepository boardRepository;
+
+
+    // 게시판 목록 조회
+    public List<SearchListBoard> searchListBoard(
+        Long userId, int page, int size, ListBoard listBoard) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("boardId").descending());
+
+        List<SearchListBoard> searchListBoards = new ArrayList<>();
+
+        List<Object[]> boardList = boardRepository.findBoardList(
+            userId, listBoard.getBoardTitle(), listBoard.getNickName(), pageable);
+
+        for (Object[] board : boardList) {
+            SearchListBoard searchListBoard = SearchListBoard.builder()
+                .boardId((Long) board[0])
+                .boardTitle((String) board[1])
+                .userId((Long) board[2])
+                .userNickName((String) board[3])
+                .createDate((LocalDateTime) board[4])
+                .build();
+
+            searchListBoards.add(searchListBoard);
+        }
+
+        return searchListBoards;
+    }
+
+
+    // 게시판 내용 조회
+    public SearchContentBoard searchContentBoard(Long userId, Long categoryId, Long boardId) {
+
+        Category category = categoryRepository.findByCategoryId(categoryId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_CATEGORY));
+
+        User user = checkUser(userId, category.getCategoryRank());
+
+        Board board = boardRepository.findByBoardId(boardId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_BOARD));
+
+        if (!board.isBoardPublicFlag() && !userId.equals(board.getUser().getUserId())) {
+            throw new GlobalException(CLOSED_BOARD);
+        }
+
+        return BoardDto.SearchContentBoard.builder()
+            .userId(user.getUserId())
+            .userNickName(user.getUserNickName())
+            .boardId(board.getBoardId())
+            .boardTitle(board.getBoardTitle())
+            .boardContent(board.getBoardContent())
+            .createDate(board.getCreateDate())
+            .build();
+    }
+
+
+    // 저장
+    @Transactional
+    public SearchContentBoard addBoard(Long userId, MergeBoard mergeBoard) {
+
+        Category category = checkCategory(mergeBoard.getCategoryId());
+
+        User user = checkUser(userId, category.getCategoryRank());
+
+        Board board = boardRepository.save(Board.builder()
+            .boardTitle(mergeBoard.getBoardTitle())
+            .boardContent(mergeBoard.getBoardContent())
+            .boardPublicFlag(mergeBoard.isBoardPublicFlag())
+            .build());
+
+        user.getBoards().add(board);
+        category.getBoards().add(board);
+
+        return searchContentBoard(userId, category.getCategoryId(), board.getBoardId());
+    }
+
+
+    // 수정
+    @Transactional
+    public SearchContentBoard modifyBoard(
+        Long userId, Long boardId, MergeBoard mergeBoard) {
+
+        Category category = checkCategory(mergeBoard.getCategoryId());
+
+        User user = checkUser(userId, category.getCategoryRank());
+
+        Board board = boardRepository.findByBoardId(boardId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_BOARD));
+
+        if (!userId.equals(board.getUser().getUserId())) {
+            throw new GlobalException(NOT_MATCH_LOGIN_ID);
+        }
+
+        board.setCategory(category);
+        board.setBoardTitle(mergeBoard.getBoardTitle());
+        board.setBoardContent(mergeBoard.getBoardContent());
+        board.setBoardPublicFlag(mergeBoard.isBoardPublicFlag());
+
+        user.getBoards().add(board);
+        category.getBoards().add(board);
+
+        return searchContentBoard(userId, category.getCategoryId(), board.getBoardId());
+    }
+
+
+    // 삭제
+    @Transactional
+    public List<SearchListBoard> deleteBoard(Long userId, Long boardId) {
+
+        Board board = boardRepository.findByBoardId(boardId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_BOARD));
+
+        if (!userId.equals(board.getUser().getUserId())) {
+            throw new GlobalException(NOT_MATCH_LOGIN_ID);
+        }
+
+        boardRepository.delete(board);
+
+        ListBoard listBoard = ListBoard.builder()
+            .boardTitle("")
+            .nickName("")
+            .build();
+
+        return searchListBoard(userId, 0, 20, listBoard);
+    }
+
+
+    // 게시판 분류 확인
+    public Category checkCategory(Long categoryId) {
+        Category category = categoryRepository.findByCategoryId(categoryId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_CATEGORY));
+
+        if (!category.isCategoryUesFlag()) {
+            throw new GlobalException(NOT_FIND_CATEGORY);
+        }
+
+        return category;
+    }
+
+
+    // 사용자 확인
+    public User checkUser(Long userId, RankType categoryRankType) {
+
+        User user = userRepository.findByUserId(userId)
+            .orElseThrow(() -> new GlobalException(NOT_FIND_LOGIN_ID));
+
+        if (user.getUserRank().compareTo(categoryRankType) < 0) {
+            throw new GlobalException(NOT_MATCH_USER_RANK);
+        }
+
+        return user;
+    }
+}


### PR DESCRIPTION
### FEAT : Board(게시판) 기능 추가

**AS-IS**
1. 게시판
    (1) 로그인, 등급 여부 없이 조회가 가능하다. 단 비공개 글은 조회할 수 없다.
    (2) 게시글은 최신순으로 조회되고, 제목, 닉네임으로 검색할 수 있고 비공개 글은 작성자와 로그인한 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;아이디가 일치 시 조회된다.
    (3) 로그인을 진행 후 등급에 맞는 글의 내용을 볼 수 있다.
    (4) 로그인을 진행해야 작성할 수 있다.
    (5) 게시판 분류에 따라 등급이 나누어져 있어서 등급에 맞게 작성할 수 있다.
    (6) 공개 여부를 선택할 수 있다. (공개:전체, 비공개:본인)

**TO-BE**
1. 게시판
    (1) CRUD 개발
    - [x] 로그인, 등급 여부 없이 조회가 가능하다. 단 비공개 글은 조회할 수 없다.
    - [x] 게시글은 최신순으로 조회되고, 제목, 닉네임으로 검색할 수 있고 비공개 글은 작성자와 로그인한 
    아이디가 일치 시 조회된다.
    - [x] 로그인을 진행 후 등급에 맞는 글의 내용을 볼 수 있다.
    - [x] 로그인을 진행해야 작성할 수 있다.
    - [x] 게시판 분류에 따라 등급이 나누어져 있어서 등급에 맞게 작성할 수 있다.
    - [x] 공개 여부를 선택할 수 있다. (공개:전체, 비공개:본인)

### FeedBack

**AS-IS**
1.  게시판
    (1) list 조회시 배열 수정
    (2) URI 수정 (행위 및 질의문은 분리 또는 RequestBody)
    (3) jpa 쿼리 조회 projection을 사용
2. 토큰
    (1) 상수 처리 변수명 지정

**TO-BE**
1. 게시판
    - [x] list 조회시 배열 수정
    - [x] URI 수정 (행위 및 질의문은 분리 또는 RequestBody)
    - [x] jpa 쿼리 조회 projection을 사용
       (1) interface projection 로 진행 
       (2) class projection 사용 시  조회 쿼리에 select new com.example.board.domain.dto(칼럼명) from 테이블 형식으로 진행
2. 토큰
    - [x]  상수 처리 변수명 지정


### 테스트
1. scratch_user.http 를 통한 회원 가입 및 로그인 진행
4. scratch_rankupstandard.http  를 통한 등업 기준 진행
5. scratch_category.http 를 통한 게시판 분류 진행
6. scratch_board.http 를 생성하여 CRUD 테스트